### PR TITLE
Fix mixed-content warning on demo site

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="description" content="">
-        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
         <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.8.3.min.js"><\/script>')</script>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Open Source Bible Data</title>


### PR DESCRIPTION
Demo site was broken in Firefox, due to jQuery being blocked for accessing an insecure URL. Fixed to match protocol in use.